### PR TITLE
update campout

### DIFF
--- a/frontend/app/campout/layout.tsx
+++ b/frontend/app/campout/layout.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
-    title: "TL 411 – SFA Campout (April 2025)",
-    description: "TL 411 – SFA Campout (April 2025)",
+    title: "TL 411 – Lake Brownwood Campout (Fall 2025)",
+    description: "TL 411 – Lake Brownwood Campout (Fall 2025)",
   };
   
   export default function CampoutLayout({

--- a/frontend/app/campout/page.tsx
+++ b/frontend/app/campout/page.tsx
@@ -2,7 +2,7 @@ export default function Campout() {
   return (
     <main className="min-h-screen bg-base-100 text-base-content">
       <iframe
-        src="https://cream-pheasant-327.notion.site/ebd/1dffb209725980f2a181f31665bf4200"
+        src="https://cream-pheasant-327.notion.site/TL-411-Lake-Brownwood-Campout-Fall-2025-27dfb209725980d1bb65c651e59fc41c"
         className="w-full h-screen md:h-[90vh] border-none"
         allowFullScreen
       />

--- a/frontend/public/sitemap-0.xml
+++ b/frontend/public/sitemap-0.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.travispollard.com/</loc><lastmod>2025-05-01T01:07:10.172Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.travispollard.com/campout/</loc><lastmod>2025-05-01T01:07:10.172Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.travispollard.com/projects/</loc><lastmod>2025-05-01T01:07:10.172Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.travispollard.com/bikeride/</loc><lastmod>2025-05-01T01:07:10.172Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.travispollard.com/resume/</loc><lastmod>2025-05-01T01:07:10.172Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.travispollard.com/</loc><lastmod>2025-04-27T17:45:46.350Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.travispollard.com/bikeride/</loc><lastmod>2025-04-27T17:45:46.352Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.travispollard.com/campout/</loc><lastmod>2025-04-27T17:45:46.352Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.travispollard.com/projects/</loc><lastmod>2025-04-27T17:45:46.352Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.travispollard.com/resume/</loc><lastmod>2025-04-27T17:45:46.352Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "travispollard.com",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates campout metadata and iframe to Lake Brownwood (Fall 2025) and refreshes sitemap timestamps.
> 
> - **Frontend**:
>   - **Campout page**:
>     - Update `frontend/app/campout/layout.tsx` metadata to "TL 411 – Lake Brownwood Campout (Fall 2025)".
>     - Point `frontend/app/campout/page.tsx` iframe `src` to new Notion URL for the Fall 2025 campout.
> - **SEO**:
>   - Refresh `frontend/public/sitemap-0.xml` `lastmod` timestamps and ordering for key routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb0aa52a8ef5516d467846c05210425dea9a8e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->